### PR TITLE
增加判断语句，解决cannot read property 'length' of 'null'报错问题

### DIFF
--- a/lib/printarea.js
+++ b/lib/printarea.js
@@ -97,9 +97,11 @@ var _class = function () {
         }
       });
       for (var i = 0; i < document.styleSheets.length; i++) {
-        var rules = document.styleSheets[i].cssRules || document.styleSheets[i].rules;
-        for (var b = 0; b < rules.length; b++) {
-          style += rules[b].cssText;
+        if (document.styleSheets[i].cssRules || document.styleSheets[i].rules) {
+          var rules = document.styleSheets[i].cssRules || document.styleSheets[i].rules;
+          for (var b = 0; b < rules.length; b++) {
+            style += rules[b].cssText;
+          }
         }
       }
 

--- a/src/printarea.js
+++ b/src/printarea.js
@@ -65,9 +65,11 @@ export default class {
       }
     });
     for (let i = 0 ; i < document.styleSheets.length; i++) {
-      let rules = document.styleSheets[i].cssRules || document.styleSheets[i].rules;
-      for (let b = 0 ; b < rules.length; b++) {
-        style += rules[b].cssText;
+      if (document.styleSheets[i].cssRules || document.styleSheets[i].rules) {
+        let rules = document.styleSheets[i].cssRules || document.styleSheets[i].rules;
+        for (let b = 0 ; b < rules.length; b++) {
+          style += rules[b].cssText;
+        }
       }
     }
 


### PR DESCRIPTION
加了这个判断语句，可以解决cannot read property 'length' of 'null'的报错问题。